### PR TITLE
[kxml_compiler]Added support for xs:boolean

### DIFF
--- a/kxml_compiler/creator.cpp
+++ b/kxml_compiler/creator.cpp
@@ -273,6 +273,8 @@ ClassDescription Creator::createClassDescription(
         description.addProperty( "double", targetClassName );
       } else if ( targetElement.type() == Schema::Element::Date ) {
         description.addProperty( "QDate", targetClassName );
+      } else if ( targetElement.type() == Schema::Element::Boolean ) {
+        description.addProperty( "bool", targetClassName );
       } else {
         description.addProperty( "QString", targetClassName );
       }
@@ -566,6 +568,8 @@ QString Creator::typeName( Schema::Node::Type type )
     return "int";
   } else if ( type == Schema::Element::Decimal ) {
     return "double";
+  } else if ( type == Schema::Element::Boolean ) {
+    return "bool";
   } else {
     return "QString";
   }

--- a/kxml_compiler/parsercreatordom.cpp
+++ b/kxml_compiler/parsercreatordom.cpp
@@ -334,6 +334,8 @@ QString ParserCreatorDom::stringToDataConverter( const QString &data,
     converter = data + ".toInt()";
   } else if ( type == Schema::Element::Decimal ) {
     converter = data + ".toDouble()";
+  } else if ( type == Schema::Element::Boolean ) {
+    converter = "(" + data + " == \"1\" || " + data + " == \"true\")";
   } else if ( type == Schema::Element::Date ) {
     converter = "QDate::fromString( " + data + ", \"yyyyMMdd\" )";
   } else if ( type == Schema::Element::DateTime ) {

--- a/kxml_compiler/parserxsd.cpp
+++ b/kxml_compiler/parserxsd.cpp
@@ -109,6 +109,8 @@ Schema::Document ParserXsd::parse( const XSD::Parser &parser )
             !complexType.baseTypeName().isEmpty() ) {
       if ( complexType.baseTypeName().qname() == "xs:string" ) {
         e.setBaseType( Schema::Node::String );
+      } else if ( complexType.baseTypeName().qname() == "xs:boolean" ) {
+        e.setBaseType( Schema::Node::Boolean );
       } else if ( complexType.baseTypeName().qname() == "xs:normalizedString" ) {
         e.setBaseType( Schema::Node::NormalizedString );
       } else if ( complexType.baseTypeName().qname() == "xs:token" ) {
@@ -118,6 +120,8 @@ Schema::Document ParserXsd::parse( const XSD::Parser &parser )
 
     if ( element.type().qname() == "xs:string" ) {
       e.setType( Schema::Node::String );
+    } else if ( element.type().qname() == "xs:boolean" ) {
+      e.setType( Schema::Node::Boolean );
     } else if ( element.type().qname() == "xs:normalizedString" ) {
       e.setType( Schema::Node::NormalizedString );
     } else if ( element.type().qname() == "xs:token" ) {
@@ -173,8 +177,9 @@ Schema::Document ParserXsd::parse( const XSD::Parser &parser )
         } else if ( attribute.type().qname() == "xs:integer" ) {
           a.setType( Schema::Node::Integer );
         } else if ( attribute.type().qname() == "xs:decimal" ) {
-          a.setType( Schema::Node::Decimal
-                     );
+          a.setType( Schema::Node::Decimal );
+        } else if ( attribute.type().qname() == "xs:boolean" ) {
+          a.setType( Schema::Node::Boolean );
         } else if ( attribute.type().qname() == "xs:date" ) {
           a.setType( Schema::Node::Date );
         } else {

--- a/kxml_compiler/schema.h
+++ b/kxml_compiler/schema.h
@@ -90,7 +90,7 @@ class KSCHEMA_EXPORT Node : public Annotatable
 {
   public:
     enum Type { None, String, NormalizedString, Token, Integer, Date,
-      Enumeration, ComplexType, DateTime, Decimal };
+      Enumeration, ComplexType, DateTime, Decimal, Boolean };
     Node();
     virtual ~Node();
 

--- a/kxml_compiler/tests/parserxsdtest.cpp
+++ b/kxml_compiler/tests/parserxsdtest.cpp
@@ -41,9 +41,9 @@ void ParserXsdTest::initTestCase()
 
 void ParserXsdTest::testElementParsing()
 {
-  QCOMPARE( mDoc.elements().size(), 6 );
+  QCOMPARE( mDoc.elements().size(), 7 );
 
-  QCOMPARE( mDoc.usedElements().size(), 5 );
+  QCOMPARE( mDoc.usedElements().size(), 6 );
 
   QCOMPARE( mDoc.startElement().name(), QString("person") );
 }
@@ -62,11 +62,13 @@ void ParserXsdTest::testTypeParsing()
   QCOMPARE( mDoc.element( "firstname" ).type(), Schema::Node::String );
 
   QCOMPARE( mDoc.element( "age" ).type(), Schema::Node::ComplexType );
+
+  QCOMPARE( mDoc.element( "active" ).type(), Schema::Node::Boolean );
 }
 
 void ParserXsdTest::testRelationParsing()
 {
-  QCOMPARE( mDoc.startElement().elementRelations().size(), 4 );
+  QCOMPARE( mDoc.startElement().elementRelations().size(), 5 );
 
   QCOMPARE( mDoc.startElement().attributeRelations().size(), 2 );
 

--- a/kxml_compiler/writercreator.cpp
+++ b/kxml_compiler/writercreator.cpp
@@ -185,6 +185,8 @@ QString WriterCreator::dataToStringConverter( const QString &data,
 
   if ( type == Schema::Element::Integer || type == Schema::Element::Decimal ) {
     converter = "QString::number( " + data + " )";
+  } else if ( type == Schema::Element::Boolean ) {
+    converter = data + " ? \"true\" : \"false\"";
   } else if ( type == Schema::Element::Date ) {
     converter = data + ".toString( \"yyyyMMdd\" )";
   } else if ( type == Schema::Element::DateTime ) {


### PR DESCRIPTION
Title says all. I know that the test coverage is not the best, but the kxml_compiler generates wrong parser from the tests/simple.xsd. I am planning to fix that in a separate PR and then implement a proper test. I am thinking about having a template XSD and XML and the test should autogenerate the parser from the XSD and then parse the XML. The test should check the read tags validity.