### PR TITLE
[kxml_compiler]Improve type/variable name sanitization

### DIFF
--- a/kxml_compiler/namer.cpp
+++ b/kxml_compiler/namer.cpp
@@ -23,6 +23,125 @@
 
 #include <libkode/style.h>
 
+#include <QRegularExpression>
+
+QStringList Namer::m_reservedKeyWords = QStringList()
+                                                       << "alignas"
+                                                       << "alignof"
+                                                       << "and"
+                                                       << "and_eq"
+                                                       << "asm"
+                                                       << "atomic_cancel"
+                                                       << "atomic_commit"
+                                                       << "atomic_noexcept"
+                                                       << "audit"
+                                                       << "auto"
+                                                       << "axiom"
+                                                       << "bitand"
+                                                       << "bitor"
+                                                       << "bool"
+                                                       << "break"
+                                                       << "case"
+                                                       << "catch"
+                                                       << "char"
+                                                       << "char16_t"
+                                                       << "char32_t"
+                                                       << "class"
+                                                       << "co_await"
+                                                       << "co_return"
+                                                       << "co_yield"
+                                                       << "compl"
+                                                       << "concept"
+                                                       << "const"
+                                                       << "const_cast"
+                                                       << "constexpr"
+                                                       << "continue"
+                                                       << "decltype"
+                                                       << "default"
+                                                       << "define"
+                                                       << "defined"
+                                                       << "delete"
+                                                       << "do"
+                                                       << "double"
+                                                       << "dynamic_cast"
+                                                       << "elif"
+                                                       << "else"
+                                                       << "endif"
+                                                       << "enum"
+                                                       << "error"
+                                                       << "explicit"
+                                                       << "export"
+                                                       << "extern"
+                                                       << "false"
+                                                       << "final"
+                                                       << "float"
+                                                       << "for"
+                                                       << "friend"
+                                                       << "goto"
+                                                       << "if"
+                                                       << "ifdef"
+                                                       << "ifndef"
+                                                       << "import"
+                                                       << "include"
+                                                       << "inline"
+                                                       << "int"
+                                                       << "line"
+                                                       << "long"
+                                                       << "module"
+                                                       << "mutable"
+                                                       << "namespace"
+                                                       << "new"
+                                                       << "noexcept"
+                                                       << "not"
+                                                       << "not_eq"
+                                                       << "nullptr"
+                                                       << "operator"
+                                                       << "or"
+                                                       << "or_eq"
+                                                       << "override"
+                                                       << "pragma"
+                                                       << "private"
+                                                       << "protected"
+                                                       << "public"
+                                                       << "reflexpr"
+                                                       << "register"
+                                                       << "reinterpret_cast"
+                                                       << "requires"
+                                                       << "return"
+                                                       << "short"
+                                                       << "signals"
+                                                       << "signed"
+                                                       << "sizeof"
+                                                       << "slots"
+                                                       << "static"
+                                                       << "static_assert"
+                                                       << "static_cast"
+                                                       << "struct"
+                                                       << "switch"
+                                                       << "synchronized"
+                                                       << "template"
+                                                       << "this"
+                                                       << "thread_local"
+                                                       << "throw"
+                                                       << "transaction_safe"
+                                                       << "transaction_safe_dynamic"
+                                                       << "true"
+                                                       << "try"
+                                                       << "typedef"
+                                                       << "typeid"
+                                                       << "typename"
+                                                       << "undef"
+                                                       << "union"
+                                                       << "unsigned"
+                                                       << "using"
+                                                       << "virtual"
+                                                       << "void"
+                                                       << "volatile"
+                                                       << "wchar_t"
+                                                       << "while"
+                                                       << "xor"
+                                                       << "xor_eq";
+
 QString Namer::upperFirst( const QString &str )
 {
   return KODE::Style::upperFirst( str );
@@ -46,10 +165,11 @@ QString Namer::getClassName( const Schema::Element &element )
 QString Namer::getClassName( const QString &elementName )
 {
   QString name;
-  QStringList parts = elementName.split( "_" );
+  QStringList parts = removeInvalidCharacters(elementName).split( "_" );
   foreach( QString part, parts ) {
     name += upperFirst( part );
   }
+
   return name;
 }
 
@@ -65,7 +185,7 @@ QString Namer::getAccessor( const Schema::Attribute &attribute )
 
 QString Namer::getAccessor( const QString &elementName )
 {
-  return lowerFirst( getClassName( elementName ) );
+  return checkForKeyWords( lowerFirst( getClassName( elementName ) ) );
 }
 
 QString Namer::getMutator( const Schema::Element &element )
@@ -81,4 +201,24 @@ QString Namer::getMutator( const Schema::Attribute &attribute )
 QString Namer::getMutator( const QString &elementName )
 {
   return "set" + getClassName( elementName );
+}
+
+QString Namer::removeInvalidCharacters(const QString &name)
+{
+  QString ret = name;
+  return ret.replace(QRegularExpression("[\\;\\-\\:\\,\\+\\*\\/\\<\\>\\|]"), "_");
+}
+
+QString Namer::checkForKeyWords(const QString &name)
+{
+  if (m_reservedKeyWords.contains(name)) {
+    QString ret = name;
+    return ret.append("_");
+  }
+  return name;
+}
+
+QString Namer::sanitize(const QString &name)
+{
+  return checkForKeyWords(removeInvalidCharacters(name));
 }

--- a/kxml_compiler/namer.cpp
+++ b/kxml_compiler/namer.cpp
@@ -25,7 +25,7 @@
 
 #include <QRegularExpression>
 
-QStringList Namer::m_reservedKeyWords = QStringList()
+QStringList Namer::m_reservedKeywords = QStringList()
                                                        << "alignas"
                                                        << "alignof"
                                                        << "and"
@@ -185,7 +185,7 @@ QString Namer::getAccessor( const Schema::Attribute &attribute )
 
 QString Namer::getAccessor( const QString &elementName )
 {
-  return checkForKeyWords( lowerFirst( getClassName( elementName ) ) );
+  return substituteKeywords( lowerFirst( getClassName( elementName ) ) );
 }
 
 QString Namer::getListAccessor( const QString &elementName )
@@ -214,9 +214,9 @@ QString Namer::removeInvalidCharacters(const QString &name)
   return ret.replace(QRegularExpression("[\\;\\-\\:\\,\\+\\*\\/\\<\\>\\|]"), "_");
 }
 
-QString Namer::checkForKeyWords(const QString &name)
+QString Namer::substituteKeywords(const QString &name)
 {
-  if (m_reservedKeyWords.contains(name)) {
+  if (m_reservedKeywords.contains(name)) {
     QString ret = name;
     return ret.append("_");
   }
@@ -225,5 +225,5 @@ QString Namer::checkForKeyWords(const QString &name)
 
 QString Namer::sanitize(const QString &name)
 {
-  return checkForKeyWords(removeInvalidCharacters(name));
+  return substituteKeywords(removeInvalidCharacters(name));
 }

--- a/kxml_compiler/namer.cpp
+++ b/kxml_compiler/namer.cpp
@@ -188,6 +188,11 @@ QString Namer::getAccessor( const QString &elementName )
   return checkForKeyWords( lowerFirst( getClassName( elementName ) ) );
 }
 
+QString Namer::getListAccessor( const QString &elementName )
+{
+  return QString("%1List").arg( lowerFirst( getClassName( elementName ) ) );
+}
+
 QString Namer::getMutator( const Schema::Element &element )
 {
   return getMutator( element.name() );

--- a/kxml_compiler/namer.h
+++ b/kxml_compiler/namer.h
@@ -52,7 +52,7 @@ class Namer
      * If the @param name is a reserved C/C++/Qt keyword it suffixes
      * with an underscore (_)
      */
-    static QString checkForKeyWords( const QString &name );
+    static QString substituteKeywords( const QString &name );
 
     /**
      * Returns a new version of @param name converted to a format
@@ -73,7 +73,7 @@ class Namer
     static QString lowerFirst( const QString &str );
 
   private:
-    static QStringList m_reservedKeyWords;
+    static QStringList m_reservedKeywords;
 };
 
 #endif

--- a/kxml_compiler/namer.h
+++ b/kxml_compiler/namer.h
@@ -35,6 +35,7 @@ class Namer
     static QString getAccessor( const Schema::Element & );
     static QString getAccessor( const Schema::Attribute & );
     static QString getAccessor( const QString & );
+    static QString getListAccessor( const QString & );
 
     static QString getMutator( const Schema::Element & );
     static QString getMutator( const Schema::Attribute & );

--- a/kxml_compiler/namer.h
+++ b/kxml_compiler/namer.h
@@ -40,9 +40,39 @@ class Namer
     static QString getMutator( const Schema::Attribute & );
     static QString getMutator( const QString & );
 
+    /**
+     * Replaces the characters which are forbidden
+     * in the C type/varaible names with an underscore (_)
+     * in the  @param name.
+     */
+    static QString removeInvalidCharacters( const QString & name );
+
+    /**
+     * If the @param name is a reserved C/C++/Qt keyword it suffixes
+     * with an underscore (_)
+     */
+    static QString checkForKeyWords( const QString &name );
+
+    /**
+     * Returns a new version of @param name converted to a format
+     * which could be compiled to a valid C type or variable name.
+     *
+     * The sanitization includes:
+     * - If the given string is a reserved keyword it will be
+     * suffixed with and underscore (_)
+     * - The non valid characters will be replaced with an
+     * underscore
+     */
+    static QString sanitize( const QString & name );
+
+
+
   protected:
     static QString upperFirst( const QString &str );
     static QString lowerFirst( const QString &str );
+
+  private:
+    static QStringList m_reservedKeyWords;
 };
 
 #endif

--- a/kxml_compiler/parsercreatordom.cpp
+++ b/kxml_compiler/parsercreatordom.cpp
@@ -144,13 +144,14 @@ void ParserCreatorDom::createElementParser( KODE::Class &c,
     Schema::Attribute a = creator()->document().attribute( r );
 
     if (a.enumerationValues().count()) {
-      QString enumName = KODE::Style::sanitize( a.name() );
+      QString enumName = Namer::sanitize( a.name() );
 
       if (!a.required()) { // if not required generate conditions
         code += "if (element.hasAttribute(\"" + a.name() + "\"))  {";
         code.indent();
       }
-      code += Namer::getClassName(a.name()) + "Enum" + " " + enumName+ " = " + KODE::Style::lowerFirst(Namer::getClassName(a.name())) + "EnumFromString( element.attribute( \"" + enumName + "\" ), ok  );";
+      code += Namer::getClassName(a.name()) + "Enum" + " " + enumName+ " = " +
+              KODE::Style::lowerFirst(Namer::getClassName(a.name())) + "EnumFromString( element.attribute( \"" + a.name() + "\" ), ok  );";
       code += "if (ok && *ok == false) {";
       code.indent();
       code += "qCritical() << \"Invalid string: \\\"\" << element.attribute( \"" + a.name() + "\" ) << \"\\\" in the \\\"" + a.name() + "\\\" element\";";

--- a/kxml_compiler/writercreator.cpp
+++ b/kxml_compiler/writercreator.cpp
@@ -205,11 +205,13 @@ KODE::Code WriterCreator::createAttributeWriter( const Schema::Element &element 
 
     QString data = Namer::getAccessor( a ) + "()";
     if ( a.type() != Schema::Node::Enumeration ) {
-        code += "    xml.writeAttribute( \"" + a.name() + "\", " +
-          dataToStringConverter( data, a.type() ) + " );";
+      code.addLine("xml.writeAttribute(\"" + a.name() + "\", " +
+          dataToStringConverter( data, a.type() ) + " );");
     } else if ( a.type() == Schema::Node::Enumeration ) {
-       code += "    xml.writeAttribute(\"" + a.name() + "\", " +
-               a.name() + "EnumToString( " + a.name() + "() ));";
+      code.addLine("xml.writeAttribute(\"" + a.name() + "\", " +
+                   KODE::Style::lowerFirst(Namer::getClassName(a.name())) + "EnumToString( " +
+                   KODE::Style::lowerFirst(Namer::getClassName(a.name())) + "() "
+                                                                            "));");
     }
   }
   

--- a/kxml_compiler/writercreator.cpp
+++ b/kxml_compiler/writercreator.cpp
@@ -20,6 +20,7 @@
 #include "writercreator.h"
 
 #include "namer.h"
+#include "style.h"
 
 #include <QDebug>
 
@@ -123,7 +124,7 @@ void WriterCreator::createElementWriter( KODE::Class &c,
       foreach( Schema::Relation r, element.elementRelations() ) {
         if ( r.isList() ) {
           conditions.append( "!" +
-            Namer::getAccessor( r.target() ) + "List().isEmpty()" );
+            Namer::getListAccessor( r.target() ) + "().isEmpty()" );
         }
       }
       code += "if ( " + conditions.join( " || " ) + " ) {";
@@ -138,7 +139,7 @@ void WriterCreator::createElementWriter( KODE::Class &c,
       QString type = Namer::getClassName( r.target() );
       if ( r.isList() ) {
         code += "foreach( " + type + " e, " +
-          Namer::getAccessor( r.target() ) + "List() ) {";
+          Namer::getListAccessor( r.target() ) + "() ) {";
         code.indent();
         code += "e.writeElement( xml );";
         code.unindent();

--- a/libkode/style.cpp
+++ b/libkode/style.cpp
@@ -21,6 +21,8 @@
 
 #include "style.h"
 
+#include <QRegularExpression>
+
 using namespace KODE;
 
 class Style::Private
@@ -57,7 +59,7 @@ Style& Style::operator=( const Style &other )
 QString Style::className( const QString &str )
 {
   Q_ASSERT(!str.isEmpty());
-  QString cl = sanitize( upperFirst( str ));
+  QString cl = upperFirst( str );
   return cl;
 }
 
@@ -67,27 +69,6 @@ QString Style::upperFirst( const QString &str )
     return str;
 
   return str[ 0 ].toUpper() + str.mid( 1 );
-}
-
-QString Style::sanitize(const QString &str)
-{
-    if (str == "class") {
-        return "class_name";
-    }
-
-    if (str == "signals") {
-        return "signal_s";
-    }
-
-    if (str == "slots") {
-        return "slot_s";
-    }
-
-    QString ret = str;
-    ret = ret.replace(QLatin1Char('-'), QLatin1Char('_'));
-    ret = ret.replace(QLatin1Char(';'), QLatin1Char('_'));
-    ret = ret.replace(QLatin1Char(':'), QLatin1Char('_'));
-    return ret;
 }
 
 QString Style::lowerFirst( const QString &str )

--- a/libkode/style.h
+++ b/libkode/style.h
@@ -71,12 +71,6 @@ class KODE_EXPORT Style
     static QString upperFirst( const QString &str );
 
     /**
-     * Returns a new version of @param str converted to a format
-     * which could be compiled
-     */
-    static QString sanitize( const QString &str );
-
-    /**
      * Returns a new version of @param str with the first
      * character be lowercase.
      */


### PR DESCRIPTION
This PR improves the sanitization of the generated C++ variable/type names by performing the following:
- It suffixes the reserved C/C++/Qt names with an underscore (I came across some XSD containing slots/signals)
- It replaces more reserved characters with an underscore
- More sanitization done on the enum items parsing/generation.

Ps. if you know better name for this than sanitization please let me know ;).