### PR TITLE
Fix sequence occurence parsing

### DIFF
--- a/kxml_compiler/tests/parserxsdtest.cpp
+++ b/kxml_compiler/tests/parserxsdtest.cpp
@@ -41,7 +41,7 @@ void ParserXsdTest::initTestCase()
 
 void ParserXsdTest::testElementParsing()
 {
-  QCOMPARE( mDoc.elements().size(), 6 );
+  QCOMPARE( mDoc.elements().size(), 10 );
 
   QCOMPARE( mDoc.usedElements().size(), 5 );
 
@@ -70,12 +70,26 @@ void ParserXsdTest::testRelationParsing()
 
   QCOMPARE( mDoc.startElement().attributeRelations().size(), 2 );
 
+  QCOMPARE( mDoc.element( "beers" ).elementRelations().size(), 1 );
+
 //   foreach( Schema::Relation e, doc.startElement().attributeRelations() ) {
 //     if( e.target() == QString("id") )
 //       QCOMPARE( e.isRequired(), true );
 //     else if( e.target() == QString("cc") )
 //       QCOMPARE( e.isRequired(), false );
-//   }
+  //   }
+}
+
+void ParserXsdTest::testSequenceOccurenceParsing()
+{
+  QCOMPARE( mDoc.element("beers").elementRelations().first().minOccurs(), 1 );
+  QCOMPARE( mDoc.element("beers").elementRelations().first().maxOccurs(), (int)Schema::Relation::Unbounded );
+}
+
+void ParserXsdTest::testSequenceElementOccurenceParsing()
+{
+  QCOMPARE( mDoc.element("wines").elementRelations().first().minOccurs(), 1 );
+  QCOMPARE( mDoc.element("wines").elementRelations().first().maxOccurs(), 2 );
 }
 
 QTEST_MAIN(ParserXsdTest)

--- a/kxml_compiler/tests/parserxsdtest.h
+++ b/kxml_compiler/tests/parserxsdtest.h
@@ -34,6 +34,8 @@ private slots:
     void testTypeParsing();
     void testAttributeParsing();
     void testRelationParsing();
+    void testSequenceOccurenceParsing();
+    void testSequenceElementOccurenceParsing();
 
 private:
     Schema::Document mDoc;

--- a/kxml_compiler/tests/simple.xsd
+++ b/kxml_compiler/tests/simple.xsd
@@ -13,11 +13,29 @@
     </xs:complexType>
   </xs:element>
   
+    <xs:element name="beers">
+    <xs:complexType>
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:element ref="beer"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
+    <xs:element name="wines">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="wine"  minOccurs="1" maxOccurs="2" />
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+  
   <xs:element name="firstname" type="xs:string"/>
   <xs:element name="surname" type="xs:string"/>
   <xs:element name="age" type="xs:integer"/>
   <xs:element name="weight" type="xs:decimal"/>
   <xs:element name="notused" type="xs:integer"/>
+  <xs:element name="beer" type="xs:string"/>
+  <xs:element name="wine" type="xs:string"/>
   
   <xs:attributeGroup name="attlist.person">
     <xs:attribute name="id" use="required"/>

--- a/schema/parser.cpp
+++ b/schema/parser.cpp
@@ -341,8 +341,21 @@ void Parser::parseCompositor( ParserContext *context,
           newElement = parseElement( context, childElement,
             ct.nameSpace(), element );
         } else {
-          newElement = parseElement( context, childElement,
-            ct.nameSpace(), childElement );
+          if ( isSequence ) {
+            // occurence attributes can be either in the
+            // parent (sequence) to on the current element
+            if ( childElement.hasAttribute("minOccurs") ||
+                 childElement.hasAttribute("maxOccurs")) {
+              newElement = parseElement( context, childElement,
+                ct.nameSpace(), childElement );
+            } else {
+              newElement = parseElement( context, childElement,
+                ct.nameSpace(), element );
+            }
+          } else {
+            newElement = parseElement( context, childElement,
+              ct.nameSpace(), childElement );
+          }
         }
         newElements.append( newElement );
         compositor.addChild( csName );


### PR DESCRIPTION
The current parser does not properly parse sequences like this:

```
 <element name='signals'>
  <complexType>
   <sequence minOccurs='0' maxOccurs='unbounded'>
    <element ref='t:signal'/>
   </sequence>
  </complexType>
 </element>
```

The current code always looks for the occurrence attributes on the elements and ignored the occurrence attributes on the sequence.

This PR modifies this behaviour: if the element's attributes does not contain min/maxOccurrences it uses the sequence's min/maxOccurrence attributes. 