### PR TITLE
[kxml_compiler]Decrease private/public/protected section change labels in the generated headers

### DIFF
--- a/kxml_compiler/creator.cpp
+++ b/kxml_compiler/creator.cpp
@@ -230,7 +230,7 @@ void Creator::createCrudFunctions( KODE::Class &c, const QString &type )
 ClassDescription Creator::createClassDescription(
   const Schema::Element &element )
 {
-  ClassDescription description( Namer::getClassName( element ) );
+  ClassDescription description( Namer::getClassName( element.name() ) );
 
   foreach( Schema::Relation r, element.attributeRelations() ) {
     Schema::Attribute a = mDocument.attribute( r );
@@ -253,7 +253,7 @@ ClassDescription Creator::createClassDescription(
   foreach( Schema::Relation r, element.elementRelations() ) {
     Schema::Element targetElement = mDocument.element( r );
 
-    QString targetClassName = Namer::getClassName( targetElement );
+    QString targetClassName = Namer::getClassName( targetElement.name() );
 
     if ( targetElement.text() && !targetElement.hasAttributeRelations() &&
          !r.isList() ) {
@@ -299,7 +299,7 @@ ClassDescription Creator::createClassDescription(
 
 void Creator::createClass( const Schema::Element &element )
 {
-  QString className = Namer::getClassName( element  );
+  QString className = Namer::getClassName( element.name() );
 
   if ( mVerbose ) {
     qDebug() <<"Creator::createClass()" << element.identifier() << className;
@@ -436,7 +436,7 @@ void Creator::setDtd( const QString &dtd )
 void Creator::createFileWriter( const Schema::Element &element )
 {
   WriterCreator writerCreator( mFile, mDocument, mDtd );
-  writerCreator.createFileWriter( Namer::getClassName( element ),
+  writerCreator.createFileWriter( Namer::getClassName( element.name() ),
     errorStream() );
 }
 

--- a/kxml_compiler/creator.cpp
+++ b/kxml_compiler/creator.cpp
@@ -568,7 +568,6 @@ QString Creator::typeName( Schema::Node::Type type )
   }
 }
 
-
 ParserCreator::ParserCreator( Creator *c )
   : mCreator( c )
 {

--- a/kxml_compiler/kxml_compiler.pro
+++ b/kxml_compiler/kxml_compiler.pro
@@ -30,7 +30,6 @@ HEADERS += \
     parserxml.h \
     parserrelaxng.h \
     parsercreatordom.h \
-    namer.h \
     creator.h \
     classdescription.h
 
@@ -41,7 +40,6 @@ SOURCES += \
     parserxml.cpp \
     parserrelaxng.cpp \
     parsercreatordom.cpp \
-    namer.cpp \
     kxml_compiler.cpp \
     creator.cpp \
     classdescription.cpp

--- a/kxml_compiler/parsercreatordom.cpp
+++ b/kxml_compiler/parsercreatordom.cpp
@@ -191,7 +191,7 @@ void ParserCreatorDom::createFileParser( const Schema::Element &element )
 {
 //   qDebug() <<"Creator::createFileParserDom()";
 
-  QString className = Namer::getClassName( element );
+  QString className = Namer::getClassName( element.name() );
 
   KODE::Class c;
 
@@ -260,7 +260,7 @@ void ParserCreatorDom::createFileParser( const Schema::Element &element )
 
 void ParserCreatorDom::createStringParser( const Schema::Element &element )
 {
-  QString className = Namer::getClassName( element );
+  QString className = Namer::getClassName( element.name() );
 
   KODE::Class c;
 

--- a/kxml_compiler/writercreator.cpp
+++ b/kxml_compiler/writercreator.cpp
@@ -124,7 +124,7 @@ void WriterCreator::createElementWriter( KODE::Class &c,
       foreach( Schema::Relation r, element.elementRelations() ) {
         if ( r.isList() ) {
           conditions.append( "!" +
-            Namer::getListAccessor( r.target() ) + "().isEmpty()" );
+            Namer::getListAccessor( r.target()) + "().isEmpty()" );
         }
       }
       code += "if ( " + conditions.join( " || " ) + " ) {";
@@ -146,7 +146,7 @@ void WriterCreator::createElementWriter( KODE::Class &c,
         code += '}';
       } else {
         Schema::Element e = mDocument.element( r );
-        QString accessor = Namer::getAccessor( e ) + "()";
+        QString accessor = Namer::getAccessor( e.name() ) + "()";
         QString data = dataToStringConverter( accessor, e.type() );
         if ( e.text() && !e.hasAttributeRelations() ) {
           if ( e.type() == Schema::Element::String ) {
@@ -206,7 +206,7 @@ KODE::Code WriterCreator::createAttributeWriter( const Schema::Element &element 
   foreach( Schema::Relation r, element.attributeRelations() ) {
     Schema::Attribute a = mDocument.attribute( r );
 
-    QString data = Namer::getAccessor( a ) + "()";
+    QString data = Namer::getAccessor( a.name() ) + "()";
     if ( a.type() != Schema::Node::Enumeration ) {
       code.addLine("xml.writeAttribute(\"" + a.name() + "\", " +
           dataToStringConverter( data, a.type() ) + " );");

--- a/libkode/libkode.pri
+++ b/libkode/libkode.pri
@@ -15,7 +15,8 @@ HEADERS += \
     $$PWD/code.h \
     $$PWD/enum.h \
     $$PWD/file.h \
-    $$PWD/function.h
+    $$PWD/function.h \
+    $$PWD/namer.h
 
 SOURCES += \
     $$PWD/automakefile.cpp \
@@ -30,5 +31,6 @@ SOURCES += \
     $$PWD/code.cpp \
     $$PWD/enum.cpp \
     $$PWD/file.cpp \
-    $$PWD/function.cpp
+    $$PWD/function.cpp \
+    $$PWD/namer.cpp
 

--- a/libkode/namer.cpp
+++ b/libkode/namer.cpp
@@ -152,16 +152,6 @@ QString Namer::lowerFirst( const QString &str )
   return KODE::Style::lowerFirst( str );
 }
 
-QString Namer::getClassName( const Schema::Attribute &attribute )
-{
-  return getClassName( attribute.name() );
-}
-
-QString Namer::getClassName( const Schema::Element &element )
-{
-  return getClassName( element.name() );
-}
-
 QString Namer::getClassName( const QString &elementName )
 {
   QString name;
@@ -173,16 +163,6 @@ QString Namer::getClassName( const QString &elementName )
   return name;
 }
 
-QString Namer::getAccessor( const Schema::Element &element )
-{
-  return getAccessor( element.name() );
-}
-
-QString Namer::getAccessor( const Schema::Attribute &attribute )
-{
-  return getAccessor( attribute.name() );
-}
-
 QString Namer::getAccessor( const QString &elementName )
 {
   return substituteKeywords( lowerFirst( getClassName( elementName ) ) );
@@ -190,17 +170,7 @@ QString Namer::getAccessor( const QString &elementName )
 
 QString Namer::getListAccessor( const QString &elementName )
 {
-  return QString("%1List").arg( lowerFirst( getClassName( elementName ) ) );
-}
-
-QString Namer::getMutator( const Schema::Element &element )
-{
-  return getMutator( element.name() );
-}
-
-QString Namer::getMutator( const Schema::Attribute &attribute )
-{
-  return getMutator( attribute.name() );
+  return QString("%1List").arg(lowerFirst(getClassName(elementName)));
 }
 
 QString Namer::getMutator( const QString &elementName )

--- a/libkode/namer.h
+++ b/libkode/namer.h
@@ -21,24 +21,15 @@
 #ifndef NAMER_H
 #define NAMER_H
 
-#include "schema.h"
 
 #include <QString>
 
 class Namer
 {
   public:
-    static QString getClassName( const Schema::Element & );
-    static QString getClassName( const Schema::Attribute & );
     static QString getClassName( const QString & );
-
-    static QString getAccessor( const Schema::Element & );
-    static QString getAccessor( const Schema::Attribute & );
     static QString getAccessor( const QString & );
     static QString getListAccessor( const QString & );
-
-    static QString getMutator( const Schema::Element & );
-    static QString getMutator( const Schema::Attribute & );
     static QString getMutator( const QString & );
 
     /**

--- a/libkode/printer.cpp
+++ b/libkode/printer.cpp
@@ -43,6 +43,8 @@ class Printer::Private
     }
 
     void addLabel( Code& code, const QString& label );
+    void changeSection(Code &code, const QString& section, bool print = true );
+
     QString classHeader( const Class &classObject, bool publicMembers, bool nestedClass = false );
     QString classImplementation( const Class &classObject, bool nestedClass = false );
     void addFunctionHeaders( Code& code,
@@ -82,6 +84,17 @@ QString Printer::Private::formatType( const QString& type ) const
       s += ' ';
   }
   return s;
+}
+
+void Printer::Private::changeSection( Code& code, const QString &section, bool print )
+{
+  static QString currentSection;
+  if (section != currentSection) {
+    currentSection = section;
+    if (print) {
+      addLabel(code, section);
+    }
+  }
 }
 
 QString Printer::Private::classHeader( const Class &classObject, bool publicMembers, bool nestedClass )
@@ -155,11 +168,12 @@ QString Printer::Private::classHeader( const Class &classObject, bool publicMemb
     code += declMacro;
     code.newLine();
   }
+  changeSection(code, "private:", false);
 
   Class::List nestedClasses = classObject.nestedClasses();
   // Generate nestedclasses
   if ( !classObject.nestedClasses().isEmpty() ) {
-    addLabel( code, "public:" );
+    changeSection( code, "public:" );
 
     Class::List::ConstIterator it, itEnd = nestedClasses.constEnd();
     for ( it = nestedClasses.constBegin(); it != itEnd; ++it ) {
@@ -171,7 +185,7 @@ QString Printer::Private::classHeader( const Class &classObject, bool publicMemb
 
   Typedef::List typedefs = classObject.typedefs();
   if ( typedefs.count() > 0 ) {
-    addLabel( code, "public:" );
+    changeSection( code, "public:" );
     if ( mLabelsDefineIndent )
       code.indent();
 
@@ -186,7 +200,7 @@ QString Printer::Private::classHeader( const Class &classObject, bool publicMemb
 
   Enum::List enums = classObject.enums();
   if ( enums.count() > 0 ) {
-    addLabel( code, "public:" );
+    changeSection( code, "public:" );
     if ( mLabelsDefineIndent )
       code.indent();
 
@@ -234,9 +248,9 @@ QString Printer::Private::classHeader( const Class &classObject, bool publicMemb
     }
 
     if ( publicMembers )
-      addLabel( code, "public:" );
+      changeSection( code, "public:" );
     else if ( !hasPrivateFunc || hasPrivateSlot )
-      addLabel( code, "private:" );
+      changeSection( code, "private:" );
 
     if (mLabelsDefineIndent)
       code.indent();
@@ -476,7 +490,7 @@ void Printer::Private::addFunctionHeaders( Code& code,
     Function f = *it;
     if ( f.access() == access ) {
       if ( !hasAccess ) {
-        addLabel( code, f.accessAsString() + ':' );
+        changeSection( code, f.accessAsString() + ':');
         hasAccess = true;
       }
       if ( mLabelsDefineIndent )


### PR DESCRIPTION
In the generated codes there were more than one public: section label in
the header (before the enums, before the members etc.). The number of
the necessary section changes will be reduced to the minimal.