### PR TITLE
[kxml_compiler]Add support for xs:int parsing

### DIFF
--- a/kxml_compiler/creator.cpp
+++ b/kxml_compiler/creator.cpp
@@ -260,8 +260,10 @@ ClassDescription Creator::createClassDescription(
       if ( mVerbose ) {
         qDebug() << "  FLATTEN";
       }
-      if ( targetElement.type() == Schema::Element::Integer ) {
-        description.addProperty( "int", targetClassName );
+      if ( targetElement.type() == Schema::Element::Int ) {
+        description.addProperty( "qint32", targetClassName );
+      } else if ( targetElement.type() == Schema::Element::Integer ) {
+        description.addProperty( "qlonglong", targetClassName );
       } else if ( targetElement.type() == Schema::Element::Decimal ) {
         description.addProperty( "double", targetClassName );
       } else if ( targetElement.type() == Schema::Element::Date ) {
@@ -556,8 +558,10 @@ QString Creator::typeName( Schema::Node::Type type )
     return "QDateTime";
   } else if ( type == Schema::Element::Date ) {
     return "QDate";
+  } else if ( type == Schema::Element::Int ) {
+    return "qint32";
   } else if ( type == Schema::Element::Integer ) {
-    return "int";
+    return "qlonglong";
   } else if ( type == Schema::Element::Decimal ) {
     return "double";
   } else if ( type == Schema::Element::Boolean ) {

--- a/kxml_compiler/parsercreatordom.cpp
+++ b/kxml_compiler/parsercreatordom.cpp
@@ -324,8 +324,10 @@ QString ParserCreatorDom::stringToDataConverter( const QString &data,
   Schema::Node::Type type )
 {
   QString converter;
-  if ( type == Schema::Element::Integer ) {
+  if ( type == Schema::Element::Int ) {
     converter = data + ".toInt()";
+  } else if ( type == Schema::Element::Integer ) {
+    converter = data + ".toLongLong()";
   } else if ( type == Schema::Element::Decimal ) {
     converter = data + ".toDouble()";
   } else if ( type == Schema::Element::Boolean ) {

--- a/kxml_compiler/parserxsd.cpp
+++ b/kxml_compiler/parserxsd.cpp
@@ -177,6 +177,8 @@ Schema::Document ParserXsd::parse( const XSD::Parser &parser )
           a.setType( Schema::Node::String );
         } else if ( attribute.type().qname() == "xs:integer" ) {
           a.setType( Schema::Node::Integer );
+        } else if ( attribute.type().qname() == "xs:int" ) {
+          a.setType( Schema::Node::Int );
         } else if ( attribute.type().qname() == "xs:decimal" ) {
           a.setType( Schema::Node::Decimal );
         } else if ( attribute.type().qname() == "xs:boolean" ) {

--- a/kxml_compiler/schema.h
+++ b/kxml_compiler/schema.h
@@ -90,8 +90,20 @@ class KSCHEMA_EXPORT Annotatable
 class KSCHEMA_EXPORT Node : public Annotatable
 {
   public:
-    enum Type { None, String, NormalizedString, Token, Integer, Date,
-      Enumeration, ComplexType, DateTime, Decimal, Boolean };
+    enum Type {
+      None,
+      String,
+      NormalizedString,
+      Token,
+      Integer, // xs:integer -> integer unbounded value
+      Int, // xs:int -> signed 32-bit integer
+      Date,
+      Enumeration,
+      ComplexType,
+      DateTime,
+      Decimal,
+      Boolean
+    };
     Node();
     virtual ~Node();
 

--- a/kxml_compiler/writercreator.cpp
+++ b/kxml_compiler/writercreator.cpp
@@ -184,7 +184,9 @@ QString WriterCreator::dataToStringConverter( const QString &data,
 {
   QString converter;
 
-  if ( type == Schema::Element::Integer || type == Schema::Element::Decimal ) {
+  if ( type == Schema::Element::Integer
+       || type == Schema::Element::Integer
+       || type == Schema::Element::Decimal ) {
     converter = "QString::number( " + data + " )";
   } else if ( type == Schema::Element::Boolean ) {
     converter = data + " ? \"true\" : \"false\"";


### PR DESCRIPTION
Add support for parsing xs:int type elements to qint32 variables. This is not the same as xs:integer which is already supported. 