### PR TITLE
Do not overwrite output files if not necessary

### DIFF
--- a/kxml_compiler/kxml_compiler.cpp
+++ b/kxml_compiler/kxml_compiler.cpp
@@ -260,6 +260,7 @@ int main( int argc, char **argv )
   c.setFilename( baseName );
 
   KODE::Printer printer;
+  printer.setVerbose(verbose);
   printer.setCreationWarning( true );
   printer.setGenerator( QCoreApplication::applicationName() );
   printer.setOutputDirectory( baseDir );

--- a/libkode/printer.h
+++ b/libkode/printer.h
@@ -133,6 +133,12 @@ class KODE_EXPORT Printer
                                const QString &className = QString(),
                                bool forImplementation = false );
 
+    /**
+     * @brief setVerbose enable/disable outputting verbose logs
+     * @param verbose
+     */
+    void setVerbose( bool verbose );
+
   protected:
     /**
      * Returns the creation warning.


### PR DESCRIPTION
Do not overwrite output files in the case their content did not get changed.

This is useful because in this case the project including the generated
files will not need to recompile the unchanged files.

Fixes #30