### PR TITLE
[kxml_compiler]Add dont-create-(write|parser)-functions arguments

### DIFF
--- a/kxml_compiler/creator.cpp
+++ b/kxml_compiler/creator.cpp
@@ -88,6 +88,16 @@ void Creator::setCreateCrudFunctions( bool enabled )
   mCreateCrudFunctions = enabled;
 }
 
+void Creator::setCreateWriterFunctions( bool createWriter )
+{
+  mCreateWriterFunctions = createWriter;
+}
+
+void Creator::setCreateParserFunctions( bool createParser )
+{
+  mCreateParserFunctions = createParser;
+}
+
 void Creator::setLicense( const KODE::License &l )
 {
   mFile.setLicense( l );
@@ -385,11 +395,13 @@ void Creator::createClass( const Schema::Element &element )
     c.addEnum(e);
   }
 
-  createElementParser( c, element );
+  if ( mCreateParserFunctions )
+    createElementParser( c, element );
   
-  WriterCreator writerCreator( mFile, mDocument, mDtd );
-  writerCreator.createElementWriter( c, element );
-
+  if ( mCreateWriterFunctions ) {
+    WriterCreator writerCreator( mFile, mDocument, mDtd );
+    writerCreator.createElementWriter( c, element );
+  }
   mFile.insertClass( c );
 }
 
@@ -539,9 +551,11 @@ void Creator::create()
 {
   Schema::Element startElement = mDocument.startElement();
   setExternalClassPrefix( KODE::Style::upperFirst( startElement.name() ) );
-  createFileParser( startElement );
+  if ( mCreateParserFunctions )
+    createFileParser( startElement );
 //  setDtd( schemaFilename.replace( "rng", "dtd" ) );
-  createFileWriter( startElement );
+  if ( mCreateWriterFunctions )
+    createFileWriter( startElement );
 
   createListTypedefs();
 }

--- a/kxml_compiler/creator.h
+++ b/kxml_compiler/creator.h
@@ -65,6 +65,22 @@ class Creator
 
     void setCreateCrudFunctions( bool createCrud );
 
+    /**
+     * @brief setCreateWriterFunctions
+     * This method can be used to enable/disable the generation of the XML
+     * generating codes.
+     * @param createWriter
+     */
+    void setCreateWriterFunctions( bool createWriter = true );
+
+    /**
+     * @brief setCreateParserFunctions
+     * This method can be used to enable/disable the generation of the XML
+     * parsing codes.
+     * @param createParser
+     */
+    void setCreateParserFunctions( bool createParser = true );
+
     void setLicense( const KODE::License & );
 
     void setExportDeclaration( const QString &name );
@@ -130,6 +146,8 @@ class Creator
     bool mVerbose;
     bool mUseKde;
     bool mCreateCrudFunctions;
+    bool mCreateWriterFunctions = true;
+    bool mCreateParserFunctions = true;
     QString mExportDeclaration;
 };
 

--- a/kxml_compiler/kxml_compiler.cpp
+++ b/kxml_compiler/kxml_compiler.cpp
@@ -121,8 +121,27 @@ int main( int argc, char **argv )
               QCoreApplication::translate("main", "Create functions for dealing with data suitable for CRUD model"));
   cmdLine.addOption(createCRUDFunctionsOption);
 
+  QCommandLineOption dontCreateWriteFunctionsOption(
+        "dont-create-write-functions",
+        QCoreApplication::translate( "main", "Do not create XML generating methods to the generated classes\n"
+                                     "(useful for applications which require onyl an XML parser code)." ) );
+  cmdLine.addOption( dontCreateWriteFunctionsOption );
+
+  QCommandLineOption dontCreateParseFunctionsOption(
+        "dont-create-parse-functions",
+        QCoreApplication::translate( "main", "Do not create XML parsing methods to the generated classes\n"
+                                             "(useful for applications which require XML writing code)" ) );
+  cmdLine.addOption( dontCreateParseFunctionsOption );
+
   if (!cmdLine.parse(QCoreApplication::arguments())) {
     qCritical() << cmdLine.errorText();
+    return -1;
+  }
+
+  if ( cmdLine.isSet(dontCreateParseFunctionsOption) && cmdLine.isSet(dontCreateWriteFunctionsOption) ) {
+    qCritical() << QCoreApplication::translate( "main",
+                                                "It is not allowed to pass both dont-create-parse-functions\n"
+                                                "and dont-create-write-functions together" );
     return -1;
   }
 
@@ -223,6 +242,8 @@ int main( int argc, char **argv )
   c.setVerbose( verbose );
   c.setUseKde( cmdLine.isSet( "use-kde" ) );
   c.setCreateCrudFunctions( cmdLine.isSet( "create-crud-functions" ) );
+  c.setCreateParserFunctions( !cmdLine.isSet(dontCreateParseFunctionsOption) );
+  c.setCreateWriterFunctions( !cmdLine.isSet(dontCreateWriteFunctionsOption) );
   if ( cmdLine.isSet( "namespace" ) ) {
     c.file().setNameSpace( cmdLine.value( "namespace" ) );
   }


### PR DESCRIPTION
Added two argument to kxml_compiler to be able to generate codes without XML parser/writer functions. 