### PR TITLE
fix cmake build scripts

### DIFF
--- a/kxml_compiler/CMakeLists.txt
+++ b/kxml_compiler/CMakeLists.txt
@@ -27,7 +27,6 @@ install(
 
 set( kxml_compiler_SRCS
   classdescription.cpp
-  namer.cpp
   writercreator.cpp
   creator.cpp
   kxml_compiler.cpp

--- a/libkode/CMakeLists.txt
+++ b/libkode/CMakeLists.txt
@@ -19,6 +19,7 @@ set(kode_LIB_SRCS
    function.cpp
    variable.cpp
    membervariable.cpp
+   namer.cpp
    typedef.cpp
    statemachine.cpp
    automakefile.cpp )


### PR DESCRIPTION
fix incorrect reference to namer.cpp in the cmake build scripts