### PR TITLE
CMake project updates and Github Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.1.1
         with:
-          submodules: 'libkode'
+          submodules: recursive
       - name: Cache Qt
         id: cache-qt
         uses: actions/cache@v1.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: macos-latest, cxx: "clang++" }
+          - { os: ubuntu-latest, cxx: "g++" }
+          - { os: windows-latest, cxx: "cl" }
+    runs-on: ${{ matrix.config.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.1.1
+        with:
+          submodules: 'libkode'
+      - name: Cache Qt
+        id: cache-qt
+        uses: actions/cache@v1.2.0
+        with:
+          path: ../Qt
+          key: ${{ runner.os }}-QtCache
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2.6.2
+        with:
+          cached: ${{ steps.cache-qt.outputs.cache-hit }}
+      - name: Build with CMake in ${{ matrix.config.os }} / ${{ matrix.config.cxx }}
+        env:
+          CXX: ${{ matrix.config.cxx }}
+        run: |
+          cmake -B cmake_build
+          cmake --build cmake_build -j2 -v

--- a/.github/workflows/clang_formatter.yml
+++ b/.github/workflows/clang_formatter.yml
@@ -1,6 +1,6 @@
 name: test-clang-format
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "libkode"]
 	path = libkode
-	url = git@github.com:cornelius/libkode.git
+	url = https://github.com/cornelius/libkode.git
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,68 +1,47 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.11)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-project( kode )
+project(kode)
 
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
-
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-set(CMAKE_CXX_FLAGS "${Qt5Core_EXECUTABLE_COMPILE_FLAGS}")
-
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 find_package(Qt5Core REQUIRED)
 find_package(Qt5Xml REQUIRED)
 find_package(Qt5Network REQUIRED)
 find_package(Qt5Test REQUIRED)
 
-add_definitions( ${QT_DEFINITIONS} )
-include_directories( ${CMAKE_BINARY_DIR} )
-
-include_directories(
-    ${Qt5_INCLUDES}
-    ${Qt5_INCLUDE_DIRS}
-    ${Qt5Core_INCLUDES}
-    ${Qt5Core_INCLUDE_DIRS}
-    ${Qt5Xml_INCLUDES}
-    ${Qt5Xml_INCLUDE_DIRS}
-    ${Qt5Network_INCLUDES}
-    ${Qt5Network_INCLUDE_DIRS}
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_SOURCE_DIR}/common
-    ${CMAKE_CURRENT_SOURCE_DIR}/libkode
-    ${CMAKE_CURRENT_SOURCE_DIR}/kwsdl
+include_directories(SYSTEM
+	${CMAKE_CURRENT_SOURCE_DIR}/libkode
+	${CMAKE_CURRENT_SOURCE_DIR}/libkode/code_generation
 )
 
-
-add_subdirectory( libkode )
-add_subdirectory( common )
-add_subdirectory( schema )
-add_subdirectory( kxml_compiler )
-#add_subdirectory( kxforms )
-#add_subdirectory( kwsdl )
+add_subdirectory(libkode)
+add_subdirectory(kxml_compiler)
+#add_subdirectory(kxforms)
 
 ########### next target ###############
 
+set(KODEBIN_SOURCES kodemain.cpp)
 
-
-set( kode_bin_SRCS kodemain.cpp )
-
-add_executable(kode_bin kodemain.cpp)
-qt5_use_modules(kode_bin Core)
-qt5_use_modules(kode_bin Xml)
-qt5_use_modules(kode_bin Network)
+add_executable(kode_bin ${KODEBIN_SOURCES})
 
 # Use the Widgets module from Qt 5.
-target_link_libraries(kode_bin Qt5::Core)
-target_link_libraries(kode_bin Qt5::Xml)
-target_link_libraries(kode_bin Qt5::Network)
-target_link_libraries( kode_bin kode  )
+target_link_libraries(kode_bin
+	Qt5::Core
+	Qt5::Network
+	Qt5::Xml
+	kode
+)
 
-set_target_properties( kode_bin PROPERTIES OUTPUT_NAME kode )
+set_target_properties(kode_bin PROPERTIES OUTPUT_NAME kode)
 
 install( 
-    TARGETS kode_bin  ${INSTALL_TARGETS_DEFAULT_ARGS} 
+    TARGETS kode_bin
     RUNTIME DESTINATION bin
 )

--- a/kxml_compiler/CMakeLists.txt
+++ b/kxml_compiler/CMakeLists.txt
@@ -1,44 +1,57 @@
+set(KSCHEMA_SOURCES
+	parserrelaxng.cpp
+	parserxsd.cpp
+	parserxml.cpp
+	schema.cpp
+)
+set(KSCHEMA_HEADERS
+	parserrelaxng.h
+	parserxsd.h
+	parserxml.h
+	schema.h
+)
 
-add_subdirectory( tests )
+add_library(kschema SHARED ${KSCHEMA_SOURCES} ${KSCHEMA_HEADERS})
+target_link_libraries(kschema
+	Qt5::Xml
+	xmlschema
+	xmlcommon
+)
+
+#set_target_properties(kschema PROPERTIES VERSION ${GENERIC_LIB_VERSION} SOVERSION ${GENERIC_LIB_SOVERSION})
+
+install(
+	TARGETS kschema
+	LIBRARY DESTINATION lib
+)
 
 ########### next target ###############
 
-set( kschema_LIB_SRCS
-    parserrelaxng.cpp
-    parserxsd.cpp
-    parserxml.cpp
-    schema.cpp
+set(KXML_COMPILER_SOURCES
+	classdescription.cpp
+	creator.cpp
+	kxml_compiler.cpp
+	parsercreatordom.cpp
+	writercreator.cpp
 )
 
-
-add_library( kschema SHARED ${kschema_LIB_SRCS} )
-
-target_link_libraries( kschema  schema kxmlcommon ${QT_QTXML_LIBRARY} )
-target_link_libraries( kschema LINK_INTERFACE_LIBRARIES schema kxmlcommon )
-
-set_target_properties( kschema PROPERTIES VERSION ${GENERIC_LIB_VERSION} SOVERSION ${GENERIC_LIB_SOVERSION} )
-
-install( 
-    TARGETS kschema  ${INSTALL_TARGETS_DEFAULT_ARGS} 
-    LIBRARY DESTINATION lib
+set(KXML_COMPILER_HEADERS
+	classdescription.h
+	creator.h
+	parsercreatordom.h
+	writercreator.h
 )
 
-########### next target ###############
+add_executable(kxml_compiler ${KXML_COMPILER_SOURCES} ${KXML_COMPILER_HEADERS})
 
-set( kxml_compiler_SRCS
-  classdescription.cpp
-  writercreator.cpp
-  creator.cpp
-  kxml_compiler.cpp
-  parsercreatordom.cpp
+target_link_libraries(kxml_compiler
+	kode
+	kschema
 )
 
-add_executable( kxml_compiler ${kxml_compiler_SRCS} )
-
-target_link_libraries( kxml_compiler kode kschema )
-
-install( 
-    TARGETS kxml_compiler ${INSTALL_TARGETS_DEFAULT_ARGS} 
-    RUNTIME DESTINATION bin
+install(
+	TARGETS kxml_compiler
+	RUNTIME DESTINATION bin
 )
 
+#add_subdirectory(tests)


### PR DESCRIPTION
Updated CMake project and added Github Actions CI. Currently CI works on matrix

 Target | Linux / gcc | macOS / clang | Windows / vs2019 |
|----------|--------|-----------|-------------|
| cmake | yes | yes | yes |

There was some test framework for kxml_compiler, but it now temporary disabled. kxml_compiler fails to produce classes based for input xml files:
```
ASSERT: "!name.isEmpty()" in file /home/winterheart/playground/kode/libkode/code_generation/variable.cpp, line 51
```
I cannot find cause of that assert at the time, so I disabled testing until solution.
