### PR TITLE
Initialize Schema::Attribute::mRequired with false

### DIFF
--- a/kxml_compiler/schema.h
+++ b/kxml_compiler/schema.h
@@ -157,7 +157,7 @@ public:
     QString elementName() const;
 
 private:
-    bool mRequired;
+    bool mRequired = false;
     QString mDefVal;
     QString mElementName;
 };


### PR DESCRIPTION
Fixing this before reactivating the tests.